### PR TITLE
Add a LOCAL_NETWORK environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ docker run ... -p 80:80 -e LOCAL_NETWORK=192.168.1.0/24 --net=pia_network --name
 docker run ... --net=container:pia --name=myservice myservice
 ```
 
-This is inspired from [haugene/docker-transmission-openvpn](https://github.com/haugene/docker-transmission-openvpn).
+This is inspired by [haugene/docker-transmission-openvpn](https://github.com/haugene/docker-transmission-openvpn).

--- a/README.md
+++ b/README.md
@@ -108,3 +108,14 @@ docker run ... --net=pia_network tutum/curl curl -s http://pia/
 
 The container is started within the same network as `pia` but is not behind the VPN.
 It can access services started behind the VPN container such as the HTTP service provided by `myservice`.
+
+### Access the service from your local network
+A service created behind the VPN container will not be accessible from a client located outside of the server on which it runs. This is because Docker runs on a different IP range than such client, and therefore the client's traffic is considered as non-local and is routed out through the VPN.
+
+The environment variable LOCAL_NETWORK can be set to let the `pia` container know the range corresponding to your local network. For instance, if your local network uses IP range `192.168.1.0/24` and the service listens on port 80 (provided that the server's firewall is set to not block port 80):
+```Shell
+docker run ... -p 80:80 -e LOCAL_NETWORK=192.168.1.0/24 --net=pia_network --name=pia mrcaution/pia-openvpn
+docker run ... --net=container:pia --name=myservice myservice
+```
+
+This is inspired from [haugene/docker-transmission-openvpn](https://github.com/haugene/docker-transmission-openvpn).

--- a/openvpn.sh
+++ b/openvpn.sh
@@ -16,5 +16,10 @@ else
     set -- "$@" '--auth-user-pass' 'auth.conf' '--auth-nocache'
 fi
 
+if [ -n "$LOCAL_NETWORK" ] ; then
+    ip route add `ip route | sed -n "/^default/ s#default#$LOCAL_NETWORK#p"`
+fi
+
+
 openvpn "$@"
 


### PR DESCRIPTION
Hi,

  I am using your container to connect to PIA, it works great, thanks for that! 
  It runs on my linux server and I have a proxy and a bittorrent client running in containers that are connected to it.

  I don't want to have to log into my server to access those two services. Instead, I want to be able to access them from my PC and my phone. This does not work out of the box because my local network runs on IP range 192.168.1.0/24, whereas the containers' IP is something like 172.18.0.2.

  To fix the problem, I have added an environment variable LOCAL_NETWORK which allows me to create a route inside the PIA container, which looks like this:

 ` 192.168.1.0/24 via 172.18.0.1 dev eth0`

  So now my local traffic is no longer routed out through the VPN and I can access my proxy from my PC.

  This change is available for you to pull if you'd like. Or if you have any comment!

Regards,
Frédéric Bousquet 